### PR TITLE
Fix MailHelper lock type

### DIFF
--- a/WaterTimeServer.Shared/Helpers/MailHelper.cs
+++ b/WaterTimeServer.Shared/Helpers/MailHelper.cs
@@ -18,7 +18,10 @@ public sealed class ConfiguracaoEmail
 
 public static class EmailHelper
 {
-    private static readonly Lock _sincronizador = new();
+    // Using a simple object as a lock since `Lock` does not exist and would
+    // cause a compilation error. The lock is only used to ensure that the
+    // configuration object is replaced atomically.
+    private static readonly object _sincronizador = new();
     private static ConfiguracaoEmail _configuracao;
 
     static EmailHelper()


### PR DESCRIPTION
## Summary
- fix compile error in MailHelper by replacing `Lock` with `object`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436f1887dc8331902fbbf0ad6f6e47